### PR TITLE
Use the host Python to handle the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,17 @@ jobs:
   build:
     runs-on: windows-latest
     continue-on-error: true
-    defaults:
-      run:
-        shell: msys2 {0}
     steps:
 
     - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
 
     - uses: msys2/setup-msys2@v2
       with:
         msystem: MSYS
         update: true
-        install: base-devel msys2-devel mingw-w64-x86_64-toolchain mingw-w64-i686-toolchain git python python-pip
+        install: base-devel msys2-devel mingw-w64-x86_64-toolchain mingw-w64-i686-toolchain
 
     - name: Clone MINGW and MSYS2 packages repos
       run: |
@@ -36,7 +35,8 @@ jobs:
     - name: Process build queue
       run: |
         python -m pip install -r requirements.txt
-        GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" python get_assets.py
+        $env:GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+        python get_assets.py
         python -m pytest -v -s -ra buildqueue.py --timeout=18000
 
     - if: ${{ always() }}
@@ -47,6 +47,7 @@ jobs:
   staging:
     needs: [ build ]
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
 
     - uses: actions/download-artifact@v2

--- a/buildqueue.py
+++ b/buildqueue.py
@@ -3,6 +3,7 @@ from json import loads
 from pathlib import Path
 from subprocess import check_call
 from sys import stdout
+import shutil
 import pytest
 
 PKGEXT='.pkg.tar.zst'
@@ -19,7 +20,7 @@ def test_file(pkg):
     stdout.flush()
 
     def run_cmd(args):
-        check_call(['bash', '-c'] + [' '.join(args)], cwd=str(ROOT.parent/pkg['repo']/pkg['repo_path']))
+        check_call([shutil.which('msys2'), '-c'] + [' '.join(args)], cwd=str(ROOT.parent/pkg['repo']/pkg['repo_path']))
 
     try:
         run_cmd([


### PR DESCRIPTION
This way building packages doesn't depend on msys2 packages

@eine 