### PR TITLE
filter queue to skip packages already available in 'staging'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,11 @@ jobs:
         mkdir assets
 
     - name: Process build queue
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         python -m pip install -r requirements.txt
-        GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" python get_assets.py
+        python get_assets.py
         python -m pytest -v -s -ra buildqueue.py --timeout=18000
 
     - if: ${{ always() }}

--- a/buildqueue.py
+++ b/buildqueue.py
@@ -1,12 +1,12 @@
+from os import environ
+from github import Github
 from urllib.request import urlopen
 from json import loads
 from pathlib import Path
 from subprocess import check_call
 from sys import stdout
+import fnmatch
 import pytest
-
-PKGEXT='.pkg.tar.zst'
-SRCEXT='.src.tar.gz'
 
 ROOT = Path(__file__).resolve().parent
 
@@ -39,7 +39,7 @@ def test_file(pkg):
             '--skippgpcheck',
             '--allsource'
         ] + ([] if isMSYS else ['--config', '/etc/makepkg_mingw64.conf']))
-        run_cmd(['mv', '*%s' % PKGEXT, '*%s' % SRCEXT, '../../msys2-devtools/assets/'])
+        run_cmd(['mv', '*.pkg.tar.*', '*.src.tar.gz', '../../msys2-devtools/assets/'])
         print('::endgroup::')
         stdout.flush()
     except:
@@ -48,7 +48,39 @@ def test_file(pkg):
         pytest.fail()
 
 def pytest_generate_tests(metafunc):
+    gh = Github(environ["GITHUB_TOKEN"])
+    #gh = Github(environ["GITHUB_USER"], environ["GITHUB_PASS"])
+
+    assets = [
+        asset.name
+        for asset in gh.get_repo('msys2/msys2-devtools').get_release('staging').get_assets()
+    ]
+
+    tasks = []
+    done = []
+
+    for pkg in loads(urlopen("https://packages.msys2.org/api/buildqueue").read()):
+        isMSYS = pkg['repo_url'].split('/')[-1][0:5] == 'MSYS2'
+        isDone = True
+        for item in pkg['packages']:
+            if not fnmatch.filter(assets, '%s-%s-*.pkg.tar.*' % (
+                item,
+                pkg['version']
+            )):
+                isDone = False
+                break
+        if isDone:
+            done.append(pkg)
+        else:
+            tasks.append(pkg)
+
+    print("\nSKIPPED packages; already in 'staging':")
+    for pkg in done:
+        print(" -", pkg['repo_path'])
+
+    # Packages that take too long to build, and should be handled manually
+    skip = ['mingw-w64-clang']
+
     metafunc.parametrize("pkg", [
-        pkg for pkg in loads(urlopen("https://packages.msys2.org/api/buildqueue").read())
-        if pkg['repo_path'] not in ('mingw-w64-clang')
+        pkg for pkg in tasks if pkg['repo_path'] not in skip
     ])

--- a/get_assets.py
+++ b/get_assets.py
@@ -13,7 +13,7 @@ print(tabulate(
         asset.size,
         asset.created_at,
         asset.updated_at,
-        asset.browser_download_url
+        #asset.browser_download_url
     ] for asset in assets],
-    headers=["name", "size", "created", "updated", "url"]
+    headers=["name", "size", "created", "updated"] #, "url"]
 ))


### PR DESCRIPTION
This is a draft to avoid rebuilding packages that are already in staging. Currently, the logic is to check `pkg['repo_path'], pkg['version'], SRCEXT` from the info provided by the API.

It seems to work with some packages (+10 are skipped), but not with others. E.g. `mingw-w64-bc-1.06-2.src.tar.gz` exists but it is not skipped...

/cc @lazka @elieux 