### PR TITLE
sbom: add support for exracting versions from CPEs

### DIFF
--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,10 +1,26 @@
-from msys2_devtools.sbom import parse_cpe, extract_upstream_version, generate_components
+from msys2_devtools.sbom import parse_cpe, extract_upstream_version, generate_components, build_cpe22
 
 
 def test_parse_cpe():
-    assert parse_cpe("cpe:/a:cryptopp:crypto%2b%2b:8.9.0") == ("cryptopp", "crypto++")
-    assert parse_cpe("cpe:2.3:a:cryptopp:crypto\\+\\+:8.9.0") == ("cryptopp", "crypto++")
-    assert parse_cpe("cpe:2.3:a:ncurses_project:ncurses") == ("ncurses_project", "ncurses")
+    assert parse_cpe("cpe:/") == (None, None, None, None)
+    assert parse_cpe("cpe:/a:cryptopp:crypto%2b%2b:8.9.0") == ("a", "cryptopp", "crypto++", "8.9.0")
+    assert parse_cpe("cpe:/a:cryptopp:crypto%2b%2b") == ("a", "cryptopp", "crypto++", None)
+    assert parse_cpe("cpe:/a::crypto%2b%2b") == ("a", None, "crypto++", None)
+    assert parse_cpe("cpe:2.3:a:cryptopp:crypto\\+\\+:8.9.0") == ("a", "cryptopp", "crypto++", "8.9.0")
+    assert parse_cpe("cpe:2.3:a:ncurses_project:ncurses") == ("a", "ncurses_project", "ncurses", None)
+    assert parse_cpe("cpe:2.3:a:foo\\:bar:quux") == ("a", "foo:bar", "quux", None)
+    assert parse_cpe("cpe:2.3:a:foo\\\\:bar") == ("a", "foo\\", "bar", None)
+    assert parse_cpe("cpe:2.3:a:*:bar") == ("a", None, "bar", None)
+    assert parse_cpe("cpe:2.3:a:") == ("a", None, None, None)
+    assert parse_cpe("cpe:2.3:a:\\*:bar") == ("a", "*", "bar", None)
+
+
+def test_build_cpe():
+    assert build_cpe22("a", "cryptopp", "crypto++", "8.9.0") == "cpe:/a:cryptopp:crypto%2B%2B:8.9.0"
+    assert build_cpe22("a", "cryptopp", "crypto++", None) == "cpe:/a:cryptopp:crypto%2B%2B"
+    assert build_cpe22("a", None, None, None) == "cpe:/a"
+    assert build_cpe22(*parse_cpe("cpe:/a::bar")) == "cpe:/a::bar"
+    assert build_cpe22(*parse_cpe("cpe:2.3:a:*:bar")) == "cpe:/a::bar"
 
 
 def test_extract_upstream_version():
@@ -54,4 +70,13 @@ def test_generate_components():
     assert components[0].name == "django"
     assert components[0].version == "42"
     assert components[0].purl is None
-    assert components[0].cpe == "cpe:/a:djangoproject:django:"
+    assert components[0].cpe == "cpe:/a:djangoproject:django:42"
+
+    # cpe with version
+    components = generate_components({"srcinfo": srcinfo, "extra": {"references": [
+        "cpe: cpe:/a:djangoproject:django:1.2.3"
+    ]}})
+    assert components[0].name == "django"
+    assert components[0].version == "1.2.3"
+    assert components[0].purl is None
+    assert components[0].cpe == "cpe:/a:djangoproject:django:1.2.3"


### PR DESCRIPTION
* properly implement unescaping for v2.3 CPEs
* extend the CPE we write to the sbom with the version
* always write v2.2 CPEs to the sbom since those are easier to build
* in case a CPE contains a version, use that over pkgver

Fixes #12